### PR TITLE
Correct Wikipedia link for book

### DIFF
--- a/src/epub/content.opf
+++ b/src/epub/content.opf
@@ -48,7 +48,7 @@
 		<dc:source>https://archive.org/details/trentslastcase00bent_1</dc:source>
 		<meta property="se:word-count">75532</meta>
 		<meta property="se:reading-ease.flesch">71.75</meta>
-		<meta property="se:url.encyclopedia.wikipedia">https://en.wikipedia.org/wiki/Trent%27s_Last_Case</meta>
+		<meta property="se:url.encyclopedia.wikipedia">https://en.wikipedia.org/wiki/Trent%27s_Last_Case_(novel)</meta>
 		<meta property="se:url.vcs.github">https://github.com/standardebooks/e-c-bentley_trents-last-case</meta>
 		<dc:creator id="author">E. C. Bentley</dc:creator>
 		<meta property="file-as" refines="#author">Bentley, E. C.</meta>


### PR DESCRIPTION
The original Wikipedia link for the novel actually went to a disambiguation page. The updated link from this commit/PR goes to the Wikipedia page specifically about the novel.