### PR TITLE
Various changes

### DIFF
--- a/src/epub/content.opf
+++ b/src/epub/content.opf
@@ -28,6 +28,7 @@
 		<link href="onix.xml" media-type="application/xml" properties="onix" rel="record"/>
 		<dc:title id="title">Trent’s Last Case</dc:title>
 		<meta property="file-as" refines="#title">Trent’s Last Case</meta>
+		<meta property="dcterms:alternative" refines="#title">The Woman in Black</meta>
 		<dc:subject id="subject-1">Detective and mystery stories</dc:subject>
 		<dc:subject id="subject-2">Trent, Philip (Fictitious character) -- Fiction</dc:subject>
 		<meta property="authority" refines="#subject-1">LCSH</meta>

--- a/src/epub/text/dedication.xhtml
+++ b/src/epub/text/dedication.xhtml
@@ -13,7 +13,8 @@
 			</header>
 			<p>My dear Gilbert,</p>
 			<p>I dedicate this story to you. First: because the only really noble motive I had in writing it was the hope that you would enjoy it. Second: because I owe you a book in return for <i epub:type="se:name.publication.book">The Man Who Was Thursday</i>. Third: because I said I would when I unfolded the plan of it to you, surrounded by Frenchmen, two years ago. Fourth: because I remember the past.</p>
-			<p>I have been thinking again today of those astonishing times when neither of us ever looked at a newspaper; when we were purely happy in the boundless consumption of paper, pencils, tea, and our elders’ patience; when we embraced the most severe literature, and ourselves produced such light reading as was necessary; when (in the words of Canada’s poet) we studied the works of nature, also those little frogs; when, in short, we were extremely young. For the sake of that age I offer you this book.</p>
+			<p>I have been thinking again today of those astonishing times when neither of us ever looked at a newspaper; when we were purely happy in the boundless consumption of paper, pencils, tea, and our elders’ patience; when we embraced the most severe literature, and ourselves produced such light reading as was necessary; when (in the words of Canada’s poet) we studied the works of nature, also those little frogs; when, in short, we were extremely young.</p>
+			<p>For the sake of that age I offer you this book.</p>
 			<footer>
 				<p>Yours always,</p>
 				<p epub:type="z3998:signature"><abbr epub:type="z3998:given-name">E. C.</abbr> Bentley</p>

--- a/src/epub/text/dedication.xhtml
+++ b/src/epub/text/dedication.xhtml
@@ -12,7 +12,7 @@
 				<b>Gilbert Keith Chesterton</b>.</p>
 			</header>
 			<p>My dear Gilbert,</p>
-			<p>I dedicate this story to you. First: because the only really noble motive I had in writing it was the hope that you would enjoy it. Second: because I owe you a book in return for “The Man Who Was Thursday.” Third: because I said I would when I unfolded the plan of it to you, surrounded by Frenchmen, two years ago. Fourth: because I remember the past.</p>
+			<p>I dedicate this story to you. First: because the only really noble motive I had in writing it was the hope that you would enjoy it. Second: because I owe you a book in return for <i epub:type="se:name.publication.book">The Man Who Was Thursday</i>. Third: because I said I would when I unfolded the plan of it to you, surrounded by Frenchmen, two years ago. Fourth: because I remember the past.</p>
 			<p>I have been thinking again today of those astonishing times when neither of us ever looked at a newspaper; when we were purely happy in the boundless consumption of paper, pencils, tea, and our elders’ patience; when we embraced the most severe literature, and ourselves produced such light reading as was necessary; when (in the words of Canada’s poet) we studied the works of nature, also those little frogs; when, in short, we were extremely young. For the sake of that age I offer you this book.</p>
 			<footer>
 				<p>Yours always,</p>


### PR DESCRIPTION
A summary of the proposed changes here:
1. Italicize the name of the novel _The Man Who Was Thursday_ and add semantics to it.
2. Restore missing paragraph break in the dedication. See [the page scans](https://archive.org/details/trentslastcase00bent_1/page/n10/mode/1up).
3. Add the alternate title _The Woman in Black_ to `content.opf`.